### PR TITLE
`HashDict` to `Map` for 1.2.0

### DIFF
--- a/lib/defmemo_result_table_gs.ex
+++ b/lib/defmemo_result_table_gs.ex
@@ -5,15 +5,15 @@ defmodule DefMemo.ResultTable.GS do
     GenServer backing store for the results of the function calls.
   """
   use GenServer
-   
-  def start_link do 
+
+  def start_link do
     GenServer.start_link(__MODULE__, Map.new, name: :result_table)
   end
-   
+
   def get(fun, args) do
     GenServer.call(:result_table, { :get, fun, args })
   end
-    
+
   def put(fun, args, result) do
     GenServer.cast(:result_table, { :put, fun, args, result })
     result
@@ -22,9 +22,9 @@ defmodule DefMemo.ResultTable.GS do
   def handle_call({ :get, fun, args }, _sender, map) do
     reply(Map.fetch(map, { fun, args }), map)
   end
-   
+
   def handle_cast({ :put, fun, args, result }, map) do
-    { :noreply,  Map.put(map, { fun, args }, result) }
+    { :noreply, Map.put(map, { fun, args }, result) }
   end
 
   defp reply(:error, map) do

--- a/lib/defmemo_result_table_gs.ex
+++ b/lib/defmemo_result_table_gs.ex
@@ -7,7 +7,7 @@ defmodule DefMemo.ResultTable.GS do
   use GenServer
    
   def start_link do 
-    GenServer.start_link(__MODULE__, HashDict.new, name: :result_table)
+    GenServer.start_link(__MODULE__, Map.new, name: :result_table)
   end
    
   def get(fun, args) do
@@ -19,20 +19,20 @@ defmodule DefMemo.ResultTable.GS do
     result
   end
 
-  def handle_call({ :get, fun, args }, _sender, dict) do
-    reply(HashDict.fetch(dict, { fun, args }), dict)
+  def handle_call({ :get, fun, args }, _sender, map) do
+    reply(Map.fetch(map, { fun, args }), map)
   end
    
-  def handle_cast({ :put, fun, args, result }, dict) do
-    { :noreply,  HashDict.put(dict, { fun, args }, result) }
+  def handle_cast({ :put, fun, args, result }, map) do
+    { :noreply,  Map.put(map, { fun, args }, result) }
   end
 
-  defp reply(:error, dict) do
-    { :reply, { :miss, nil }, dict }
+  defp reply(:error, map) do
+    { :reply, { :miss, nil }, map }
   end
 
-  defp reply({:ok, val}, dict) do
-   { :reply, { :hit, val }, dict }
+  defp reply({:ok, val}, map) do
+   { :reply, { :hit, val }, map }
   end
 
 end

--- a/test/defmemo_result_table_gs_test.exs
+++ b/test/defmemo_result_table_gs_test.exs
@@ -1,7 +1,7 @@
 
 defmodule DefMemo.ResultTable.GS.Test do
   use ExUnit.Case
-  """
+  @doc """
     Direct tests of the GenServer ResultTable.
   """
   alias DefMemo.ResultTable.GS, as: RT
@@ -17,13 +17,13 @@ defmodule DefMemo.ResultTable.GS.Test do
 
   test "returns {:hit, result} for a memo'd result" do
     FibMemo.fibs(20)
-    assert RT.get(@fib_memo, [20])  == {:hit, 6765} 
+    assert RT.get(@fib_memo, [20])  == {:hit, 6765}
   end
 
   # Drying up the tests
   defp do_is_test(is_name, atom,  test_value) do
     TestMemoWhen.fibs(test_value)
-    assert RT.get(@fstr, [test_value]) == {:hit, {atom, test_value} } 
+    assert RT.get(@fstr, [test_value]) == {:hit, {atom, test_value} }, is_name
   end
 
   test "returns correct result when is_binary" do
@@ -57,9 +57,9 @@ defmodule DefMemo.ResultTable.GS.Test do
   test "functions can be memoized!" do
     test_value = fn(a) -> a * 2 end
     do_is_test("is_function", :function, test_value)
-    {:hit, {:function, fnc}} = RT.get(@fstr, [test_value] ) 
+    {:hit, {:function, fnc}} = RT.get(@fstr, [test_value] )
     # functions can be memoized!? Useful if the key isnt the function itself...
-    assert fnc.(2) == 4 
+    assert fnc.(2) == 4
   end
 
   test "returns correctly when is_map" do
@@ -69,7 +69,7 @@ defmodule DefMemo.ResultTable.GS.Test do
   test "returns correctly when is_pid" do
     do_is_test("is_pid", :pid, self)
   end
-  
+
   test "returns correctly when is_port" do
   end
 
@@ -82,6 +82,6 @@ defmodule DefMemo.ResultTable.GS.Test do
 
   test "#DefMemo.ResultTable.get returns correctly when is_list and is_binary" do
     TestMemoWhen.fibs([1, 2, 3], "TEST")
-    assert RT.get(@fstr, [[1, 2, 3], "TEST"]) == {:hit, {[1, 2, 3], "TEST"} } 
+    assert RT.get(@fstr, [[1, 2, 3], "TEST"]) == {:hit, {[1, 2, 3], "TEST"} }
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,6 +36,7 @@ end
 defmodule TestMemoWhen do
   import DefMemo
 
+  defmemo fibs(n, x) when is_list(n) and is_binary(x), do: {n, x}
   # nb, is binary also covers bitstring
   defmemo fibs(n) when is_binary(n), do: {:binary, n}
   defmemo fibs(n) when is_boolean(n), do: {:boolean, n}
@@ -51,7 +52,6 @@ defmodule TestMemoWhen do
   defmemo fibs(n) when is_reference(n), do: {:reference, n}
   defmemo fibs(n) when is_tuple(n), do: {:tuple, n}
 
-  defmemo fibs(n, x) when is_list(n) and is_binary(x), do: {n, x}
   defmemo fibs(n), do: {:no_guard, n}
 end
 


### PR DESCRIPTION
Elixir 1.2.0 has soft deprecated `HashDict` in favor of `Map`.  This pull request updates the usage here.

Also eliminates some test warnings and cleans up some niggling trailing whitespace.
