### PR TITLE
Allow for normalization function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ otp_release:
   - 17.0
   - 17.1
   - 17.4
-sudo: false 
+sudo: false
 notifications:
   recipients:
     - leej@librely.com

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ I found Gustavo's Gist when looking at memoization and elixir and fixed it
 to work with version 1.0.x. Since then I've fixed a few of the problems with
 the original implementation:
 
-- will correctly memoize the results of functions with identical signatures 
+- will correctly memoize the results of functions with identical signatures
   but in different modules.
 
-- will work with 'when' guard clauses in function definitions. (That was fun!) 
+- will work with 'when' guard clauses in function definitions. (That was fun!)
 
 - Added lots of lovely tests.
 
@@ -25,11 +25,11 @@ Add defmemo to your mix.exs file:
     {:defmemo, "~> 0.1.0"}
 
 And run:
-  
+
     mix deps.get
 
 Before *using* a defmemo'd function (it's fine to define them), start_link must
-be called. e.g. 
+be called. e.g.
 
   DefMemo.start_link
 
@@ -42,7 +42,7 @@ Example
 
     defmodule FibMemo do
       import DefMemo
-         
+
       defmemo fibs(0), do: 0
       defmemo fibs(1), do: 1
       defmemo fibs(n), do: fibs(n - 1) + fibs(n - 2)
@@ -57,7 +57,7 @@ Performance
 As you would expect for something like fibs, memoization provides dramatic
 performance improvements:
 
-    UNMEMOIZED VS MEMOIZED 
+    UNMEMOIZED VS MEMOIZED
     ***********************
     fib (unmemoized)
     function -> {result, running time(μs)}

--- a/lib/defmemo.ex
+++ b/lib/defmemo.ex
@@ -35,8 +35,22 @@ defmodule DefMemo do
         defmemo fibs(1), do: 1
         defmemo fibs(n), do: fibs(n - 1) + fibs(n - 2)
       end
+
+    A second argument can be provided to normalize the arguments for
+    the memoization result lookup.  The original function arguments are
+    provided as a List to the normalization function.
+
+    # Example:
+      defmodule BadCaser do
+        defp normalize_case([x]), do: String.downcase(x)
+        defmemo slow_upper(s), normalize_case do: String.upcase(s)
+      end
+
+    This might realize time savings if `downcase` were significantly cheaper to
+    execute than `upcase` or space savings if a wide variety of mixed-case, yet
+    otherwise the same, strings were run through this code path.
   """
-  defmacro defmemo(head = {:when, _, vars = [ {f_name, _, f_vars} | _ ] }, do: body) do
+  defmacro defmemo(head = {:when, _, [ {f_name, _, f_vars} | _ ] }, do: body) do
     quote do
       def unquote(head) do
         sig = {__MODULE__, unquote(f_name)}
@@ -58,6 +72,35 @@ defmodule DefMemo do
         case ResultTable.get(sig, unquote(vars)) do
           { :hit, value } -> value
           { :miss, nil }  -> ResultTable.put(sig, unquote(vars), unquote(body))
+        end
+      end
+    end
+  end
+
+  defmacro defmemo(head = {:when, _, [ {f_name, _, f_vars} | _ ] }, normalizer, do: body) do
+    quote do
+      def unquote(head) do
+        sig = {__MODULE__, unquote(f_name)}
+        args = unquote(f_vars) |> unquote(normalizer)
+
+        case ResultTable.get(sig, args) do
+          { :hit, value }   -> value
+          { :miss, nil }    -> ResultTable.put(sig, args, unquote(body))
+        end
+      end
+    end
+  end
+
+  defmacro defmemo(head = {name, _, vars}, normalizer, do: body) do
+    quote do
+      def unquote(head) do
+        sig = {__MODULE__, unquote(name)}
+
+        args = unquote(vars) |> unquote(normalizer)
+
+        case ResultTable.get(sig, args) do
+          { :hit, value } -> value
+          { :miss, nil }  -> ResultTable.put(sig, args, unquote(body))
         end
       end
     end

--- a/lib/defmemo.ex
+++ b/lib/defmemo.ex
@@ -14,8 +14,8 @@ defmodule DefMemo do
 
     children = [ worker(DefMemo.ResultTable.GS, []) ]
 
-    Supervisor.start_link(children, 
-                            [strategy: :one_for_one, 
+    Supervisor.start_link(children,
+                            [strategy: :one_for_one,
                             name: DefMemo.ResultTable.Supervisor])
   end
 
@@ -24,13 +24,13 @@ defmodule DefMemo do
   defdelegate start_link,           to: ResultTable
 
   @doc """
-    Defines a function as being memoized. Note that DefMemo.start_link 
+    Defines a function as being memoized. Note that DefMemo.start_link
     must be called before calling a method defined with defmacro.
 
     # Example:
       defmodule FibMemo do
         import DefMemo
-         
+
         defmemo fibs(0), do: 0
         defmemo fibs(1), do: 1
         defmemo fibs(n), do: fibs(n - 1) + fibs(n - 2)
@@ -57,7 +57,7 @@ defmodule DefMemo do
 
         case ResultTable.get(sig, unquote(vars)) do
           { :hit, value } -> value
-          { :miss, nil }  -> ResultTable.put(sig, unquote(vars), unquote(body)) 
+          { :miss, nil }  -> ResultTable.put(sig, unquote(vars), unquote(body))
         end
       end
     end

--- a/lib/defmemo_result_table_gs.ex
+++ b/lib/defmemo_result_table_gs.ex
@@ -5,15 +5,15 @@ defmodule DefMemo.ResultTable.GS do
     GenServer backing store for the results of the function calls.
   """
   use GenServer
-   
-  def start_link do 
+
+  def start_link do
     GenServer.start_link(__MODULE__, Map.new, name: :result_table)
   end
-   
+
   def get(fun, args) do
     GenServer.call(:result_table, { :get, fun, args })
   end
-    
+
   def put(fun, args, result) do
     GenServer.cast(:result_table, { :put, fun, args, result })
     result
@@ -22,9 +22,9 @@ defmodule DefMemo.ResultTable.GS do
   def handle_call({ :get, fun, args }, _sender, map) do
     reply(Map.fetch(map, { fun, args }), map)
   end
-   
+
   def handle_cast({ :put, fun, args, result }, map) do
-    { :noreply,  Map.put(map, { fun, args }, result) }
+    { :noreply, Map.put(map, { fun, args }, result) }
   end
 
   defp reply(:error, map) do

--- a/lib/defmemo_result_table_gs.ex
+++ b/lib/defmemo_result_table_gs.ex
@@ -7,7 +7,7 @@ defmodule DefMemo.ResultTable.GS do
   use GenServer
    
   def start_link do 
-    GenServer.start_link(__MODULE__, HashDict.new, name: :result_table)
+    GenServer.start_link(__MODULE__, Map.new, name: :result_table)
   end
    
   def get(fun, args) do
@@ -19,20 +19,20 @@ defmodule DefMemo.ResultTable.GS do
     result
   end
 
-  def handle_call({ :get, fun, args }, _sender, dict) do
-    reply(HashDict.fetch(dict, { fun, args }), dict)
+  def handle_call({ :get, fun, args }, _sender, map) do
+    reply(Map.fetch(map, { fun, args }), map)
   end
    
-  def handle_cast({ :put, fun, args, result }, dict) do
-    { :noreply,  HashDict.put(dict, { fun, args }, result) }
+  def handle_cast({ :put, fun, args, result }, map) do
+    { :noreply,  Map.put(map, { fun, args }, result) }
   end
 
-  defp reply(:error, dict) do
-    { :reply, { :miss, nil }, dict }
+  defp reply(:error, map) do
+    { :reply, { :miss, nil }, map }
   end
 
-  defp reply({:ok, val}, dict) do
-   { :reply, { :hit, val }, dict }
+  defp reply({:ok, val}, map) do
+   { :reply, { :hit, val }, map }
   end
 
 end

--- a/test/defmemo_result_table_gs_test.exs
+++ b/test/defmemo_result_table_gs_test.exs
@@ -1,7 +1,7 @@
 
 defmodule DefMemo.ResultTable.GS.Test do
   use ExUnit.Case
-  """
+  @doc """
     Direct tests of the GenServer ResultTable.
   """
   alias DefMemo.ResultTable.GS, as: RT
@@ -17,13 +17,13 @@ defmodule DefMemo.ResultTable.GS.Test do
 
   test "returns {:hit, result} for a memo'd result" do
     FibMemo.fibs(20)
-    assert RT.get(@fib_memo, [20])  == {:hit, 6765} 
+    assert RT.get(@fib_memo, [20])  == {:hit, 6765}
   end
 
   # Drying up the tests
   defp do_is_test(is_name, atom,  test_value) do
     TestMemoWhen.fibs(test_value)
-    assert RT.get(@fstr, [test_value]) == {:hit, {atom, test_value} } 
+    assert RT.get(@fstr, [test_value]) == {:hit, {atom, test_value} }, is_name
   end
 
   test "returns correct result when is_binary" do
@@ -57,9 +57,9 @@ defmodule DefMemo.ResultTable.GS.Test do
   test "functions can be memoized!" do
     test_value = fn(a) -> a * 2 end
     do_is_test("is_function", :function, test_value)
-    {:hit, {:function, fnc}} = RT.get(@fstr, [test_value] ) 
+    {:hit, {:function, fnc}} = RT.get(@fstr, [test_value] )
     # functions can be memoized!? Useful if the key isnt the function itself...
-    assert fnc.(2) == 4 
+    assert fnc.(2) == 4
   end
 
   test "returns correctly when is_map" do
@@ -69,7 +69,7 @@ defmodule DefMemo.ResultTable.GS.Test do
   test "returns correctly when is_pid" do
     do_is_test("is_pid", :pid, self)
   end
-  
+
   test "returns correctly when is_port" do
   end
 
@@ -82,6 +82,6 @@ defmodule DefMemo.ResultTable.GS.Test do
 
   test "#DefMemo.ResultTable.get returns correctly when is_list and is_binary" do
     TestMemoWhen.fibs([1, 2, 3], "TEST")
-    assert RT.get(@fstr, [[1, 2, 3], "TEST"]) == {:hit, {[1, 2, 3], "TEST"} } 
+    assert RT.get(@fstr, [[1, 2, 3], "TEST"]) == {:hit, {[1, 2, 3], "TEST"} }
   end
 end

--- a/test/defmemo_test.exs
+++ b/test/defmemo_test.exs
@@ -48,4 +48,29 @@ defmodule DefMemo.Test do
     assert TestMemoWhen.fibs("20") == {:binary, "20"}
     assert TestMemoWhen.fibs([1, 2, 3]) == {:list, [1, 2, 3]}
   end
+
+  test "normalized function arguments return correct results" do
+
+    assert TestMemoNormalized.slow_upper("A") == TestMemoNormalized.slow_upper("a"), "single argument match"
+    assert TestMemoNormalized.slow_upper("A") != TestMemoNormalized.slow_upper("B"), "single argument mis-match"
+
+    assert TestMemoNormalized.slow_sum([1,2], false) == TestMemoNormalized.slow_sum([2,1], false), "multi-argument match"
+    assert TestMemoNormalized.slow_sum([1,2], true) != TestMemoNormalized.slow_sum([2,1], false), "multi-argument mis-match"
+
+  end
+
+  test "normalized arguments performance improves" do
+
+    {"AB", first_upper }  = TimedFunction.time fn -> TestMemoNormalized.slow_upper("Ab") end
+    {"AB", second_upper } = TimedFunction.time fn -> TestMemoNormalized.slow_upper("AB") end
+
+    assert first_upper >= second_upper, "Second run on similar slow_upper arguments is faster"
+
+    {9, first_sum }  = TimedFunction.time fn -> TestMemoNormalized.slow_sum([2,3,4], false) end
+    {9, second_sum } = TimedFunction.time fn -> TestMemoNormalized.slow_sum([4,2,3], false) end
+
+    assert first_sum >= second_sum, "Second run on similar slow_sum arguments is faster"
+
+  end
+
 end

--- a/test/defmemo_test.exs
+++ b/test/defmemo_test.exs
@@ -17,8 +17,8 @@ defmodule DefMemo.Test do
     puts "=================================="
     puts "fibs(30) -> #{inspect TimedFunction.time fn -> FibMemo.fibs(30) end}"
     puts "fibs(30) -> #{inspect TimedFunction.time fn -> FibMemo.fibs(30) end}"
-    puts "fibs(50) -> #{inspect TimedFunction.time fn -> FibMemo.fibs(50) end}" 
-    puts "fibs(50) -> #{inspect TimedFunction.time fn -> FibMemo.fibs(50) end}" 
+    puts "fibs(50) -> #{inspect TimedFunction.time fn -> FibMemo.fibs(50) end}"
+    puts "fibs(50) -> #{inspect TimedFunction.time fn -> FibMemo.fibs(50) end}"
   end
 
   test "identical function signatures in different modules return correct results" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -55,3 +55,21 @@ defmodule TestMemoWhen do
   defmemo fibs(n), do: {:no_guard, n}
 end
 
+defmodule TestMemoNormalized do
+  import DefMemo
+
+  defp normalize_case([x]), do: String.downcase(x)
+
+  defmemo slow_upper(s), normalize_case do
+    :timer.sleep(1)     # Could this be why is this code so slow?!
+    String.upcase(s)
+  end
+
+  defp normalize_many([numbers, multiply_instead]), do: [Enum.sort(numbers), multiply_instead]
+
+  defmemo slow_sum(n, multiply_instead), normalize_many do
+    :timer.sleep(1)
+    if multiply_instead, do: Enum.reduce(n, fn(x, acc) -> x * acc end), else: Enum.sum(n)
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,6 +36,7 @@ end
 defmodule TestMemoWhen do
   import DefMemo
 
+  defmemo fibs(n, x) when is_list(n) and is_binary(x), do: {n, x}
   # nb, is binary also covers bitstring
   defmemo fibs(n) when is_binary(n), do: {:binary, n}
   defmemo fibs(n) when is_boolean(n), do: {:boolean, n}
@@ -51,7 +52,6 @@ defmodule TestMemoWhen do
   defmemo fibs(n) when is_reference(n), do: {:reference, n}
   defmemo fibs(n) when is_tuple(n), do: {:tuple, n}
 
-  defmemo fibs(n, x) when is_list(n) and is_binary(x), do: {n, x}
   defmemo fibs(n), do: {:no_guard, n}
 end
 


### PR DESCRIPTION
This includes the changes from the now-closed https://github.com/os6sense/DefMemo/pull/3

The basic concept here is to allow for a normalization function such that the `:hit`s are maximized.  This should also help to reduce the space required for storing "same" result.

I am not sure the testing herein is sufficient nor that the style (and calling semantics) fit the goals of the project.  Please do let me know if there are improvements to be made or oversights to be corrected.
