### PR TITLE
Add the ability to delete a memoized result

### DIFF
--- a/lib/defmemo_result_table.ex
+++ b/lib/defmemo_result_table.ex
@@ -4,4 +4,5 @@ defmodule DefMemo.ResultTable do
   defcallback start_link :: any | nil
   defcallback get(fun :: Fun, args :: List) :: any
   defcallback put(fun :: Fun, args :: List, result :: any) :: any
+  defcallback delete(fun :: Fun, args :: List) :: any
 end

--- a/lib/defmemo_result_table_gs.ex
+++ b/lib/defmemo_result_table_gs.ex
@@ -14,6 +14,10 @@ defmodule DefMemo.ResultTable.GS do
     GenServer.call(:result_table, { :get, fun, args })
   end
 
+  def delete(fun, args) do
+    GenServer.call(:result_table, { :delete, fun, args })
+  end
+
   def put(fun, args, result) do
     GenServer.cast(:result_table, { :put, fun, args, result })
     result
@@ -21,6 +25,10 @@ defmodule DefMemo.ResultTable.GS do
 
   def handle_call({ :get, fun, args }, _sender, map) do
     reply(Map.fetch(map, { fun, args }), map)
+  end
+
+  def handle_call({ :delete, fun, args }, _sender, map) do
+    reply({ :ok, nil }, Map.delete(map, { fun, args }))
   end
 
   def handle_cast({ :put, fun, args, result }, map) do

--- a/test/defmemo_result_table_gs_test.exs
+++ b/test/defmemo_result_table_gs_test.exs
@@ -20,6 +20,15 @@ defmodule DefMemo.ResultTable.GS.Test do
     assert RT.get(@fib_memo, [20])  == {:hit, 6765}
   end
 
+  test "delete removes a memo'd result" do
+    RT.delete(@fib_memo, [10])
+    assert RT.get(@fib_memo, [10]) == {:miss, nil}
+    FibMemo.fibs(10)
+    assert RT.get(@fib_memo, [10]) == {:hit, 55}
+    RT.delete(@fib_memo, [10])
+    assert RT.get(@fib_memo, [10]) == {:miss, nil}
+  end
+
   # Drying up the tests
   defp do_is_test(is_name, atom,  test_value) do
     TestMemoWhen.fibs(test_value)


### PR DESCRIPTION
This adds the ability to delete a memoized result from the map by calling

``` elixir
DefMemo.ResultTable.GS.delete(func, args)
```

I've found this useful in testing for being able to reset a memoized object before each test.
