### PR TITLE
Add in `delete_all` function

### DIFF
--- a/lib/defmemo_result_table_gs.ex
+++ b/lib/defmemo_result_table_gs.ex
@@ -18,6 +18,10 @@ defmodule DefMemo.ResultTable.GS do
     GenServer.call(:result_table, { :delete, fun, args })
   end
 
+  def delete_all do
+    GenServer.call(:result_table, { :delete_all })
+  end
+
   def put(fun, args, result) do
     GenServer.cast(:result_table, { :put, fun, args, result })
     result
@@ -29,6 +33,10 @@ defmodule DefMemo.ResultTable.GS do
 
   def handle_call({ :delete, fun, args }, _sender, map) do
     reply({ :ok, nil }, Map.delete(map, { fun, args }))
+  end
+
+  def handle_call({ :delete_all }, _sender, _map) do
+    reply({ :ok, nil }, Map.new)
   end
 
   def handle_cast({ :put, fun, args, result }, map) do

--- a/test/defmemo_result_table_gs_test.exs
+++ b/test/defmemo_result_table_gs_test.exs
@@ -29,6 +29,19 @@ defmodule DefMemo.ResultTable.GS.Test do
     assert RT.get(@fib_memo, [10]) == {:miss, nil}
   end
 
+  test "delete_all removed all memo'd results" do
+    RT.delete_all
+    assert RT.get(@fib_memo, [10]) == {:miss, nil}
+    assert RT.get(@fib_memo, [20]) == {:miss, nil}
+    FibMemo.fibs(10)
+    FibMemo.fibs(20)
+    assert RT.get(@fib_memo, [10]) == {:hit, 55}
+    assert RT.get(@fib_memo, [20]) == {:hit, 6765}
+    RT.delete_all
+    assert RT.get(@fib_memo, [10]) == {:miss, nil}
+    assert RT.get(@fib_memo, [20]) == {:miss, nil}
+  end
+
   # Drying up the tests
   defp do_is_test(is_name, atom,  test_value) do
     TestMemoWhen.fibs(test_value)


### PR DESCRIPTION
I've got a long running process that I need to clear the memo'd results from periodically. 